### PR TITLE
Allowing stddiffs for continuous variables to be negative

### DIFF
--- a/R/rStddif.R
+++ b/R/rStddif.R
@@ -4,16 +4,14 @@
 #'@param vec_con control group category vector
 #'@return standardized differnce
 #'@export
-
-
 fun_sef_cat <- function (vec_tr, vec_con) {
-  mat_tr <- dummies::dummy(vec_tr)[,-ncol(dummies::dummy(vec_tr))]
-  mat_con <- dummies::dummy(vec_con)[,-ncol(dummies::dummy(vec_con))]
-  p_tr <- colMeans(mat_tr)
-  p_con <- colMeans(mat_con)
-  S <- (cov(mat_tr) + cov(mat_con))/2
-  es <- sqrt(t(matrix(p_tr-p_con)) %*% MASS::ginv(S) %*% matrix(p_tr-p_con))
-  return(es[,1])
+    mat_tr  <- dummies::dummy(vec_tr)[,-ncol(dummies::dummy(vec_tr))]
+    mat_con <- dummies::dummy(vec_con)[,-ncol(dummies::dummy(vec_con))]
+    p_tr    <- colMeans(mat_tr)
+    p_con   <- colMeans(mat_con)
+    S       <- (cov(mat_tr) + cov(mat_con))/2
+    es      <- sqrt(t(matrix(p_tr-p_con)) %*% MASS::ginv(S) %*% matrix(p_tr-p_con))
+    return(es[,1])
 }
 
 #'Calculate Standardized Difference between two groups.(numeric)
@@ -22,14 +20,12 @@ fun_sef_cat <- function (vec_tr, vec_con) {
 #'@param vec_con control group numeric vector
 #'@return standardized differnce
 #'@export
-
-
 fun_sef_num <- function (vec_tr, vec_con) {
-  e_tr <- mean(vec_tr)
-  e_con <- mean(vec_con)
-  S <- (var(vec_tr) + var(vec_con))/2
-  es <- sqrt((e_tr - e_con)^2/S)
-  return(es)
+    e_tr  <- mean(vec_tr)
+    e_con <- mean(vec_con)
+    S     <- (var(vec_tr) + var(vec_con))/2
+    es    <- sqrt((e_tr - e_con)^2/S)
+    return(es)
 }
 
 #'Calculate Standardized Difference between two groups.(category)
@@ -38,35 +34,34 @@ fun_sef_num <- function (vec_tr, vec_con) {
 #'@param treat_vec_name treatment columns name
 #'@return standardized differnce
 #'@export
-
 fun_sef <- function (input_data,treat_vec_name) {
-  if(ncol(input_data) != 2){
-    print("ERROR::Invarid column name!")
-  }else{
-    treat_vec <- input_data[,treat_vec_name]
-    if(length(unique(treat_vec)) < 2){
-      print("ERROR::Invarid treatment category!")
+    if(ncol(input_data) != 2){
+        print("ERROR::Invarid column name!")
     }else{
-      vec <- input_data[,!(colnames(input_data) %in% treat_vec_name)]
-      if(is.numeric(vec)){
-        vec_tr <- vec[treat_vec == unique(treat_vec)[1]]
-        vec_con <- vec[treat_vec == unique(treat_vec)[2]]
-        es <- fun_sef_num(vec_tr, vec_con)
-      }else{
-        if(length(unique(vec)) > 2){
-          vec_tr <- vec[treat_vec == unique(treat_vec)[1]]
-          vec_con <- vec[treat_vec == unique(treat_vec)[2]]
-          es <- fun_sef_cat(vec_tr, vec_con)  
+        treat_vec <- input_data[,treat_vec_name]
+        if(length(unique(treat_vec)) < 2){
+            print("ERROR::Invarid treatment category!")
         }else{
-          vec <- dummies::dummy(vec)[,1]
-          vec_tr <- vec[treat_vec == unique(treat_vec)[1]]
-          vec_con <- vec[treat_vec == unique(treat_vec)[2]]
-          es <- fun_sef_num(vec_tr, vec_con)
+            vec <- input_data[,!(colnames(input_data) %in% treat_vec_name)]
+            if(is.numeric(vec)){
+                vec_tr  <- vec[treat_vec == unique(treat_vec)[1]]
+                vec_con <- vec[treat_vec == unique(treat_vec)[2]]
+                es      <- fun_sef_num(vec_tr, vec_con)
+            }else{
+                if(length(unique(vec)) > 2){
+                    vec_tr  <- vec[treat_vec == unique(treat_vec)[1]]
+                    vec_con <- vec[treat_vec == unique(treat_vec)[2]]
+                    es      <- fun_sef_cat(vec_tr, vec_con)  
+                }else{
+                    vec     <- dummies::dummy(vec)[,1]
+                    vec_tr  <- vec[treat_vec == unique(treat_vec)[1]]
+                    vec_con <- vec[treat_vec == unique(treat_vec)[2]]
+                    es      <- fun_sef_num(vec_tr, vec_con)
+                }
+            }
+            return(es)
         }
-      }
-      return(es)
     }
-  }
 }
 
 #'Calculate Standardized Difference between two groups with dataframe.
@@ -75,26 +70,24 @@ fun_sef <- function (input_data,treat_vec_name) {
 #'@param treat_vec_name treatment columns name
 #'@return standardized differnce vector
 #'@export
-
-
 fun_sef_df <- function (input_data, treat_vec_name) {
-  input_data_res <- input_data[,!(colnames(input_data) %in% treat_vec_name)]
-  if(!is.data.frame(input_data_res)){
-    es <- fun_sef(input_data,treat_vec_name)
-    names(es) <-  colnames(input_data)[!(colnames(input_data) %in% treat_vec_name)]
-    return_vec <- es
-  }else{
-    val_names_vec <- colnames(input_data_res)
-    return_vec <- vector(length = length(val_names_vec))
-    for(i in 1:length(val_names_vec)){
-      val_neme <- val_names_vec[i]
-      input_data_tar <- input_data[,c(treat_vec_name,val_neme)]
-      es <- fun_sef(input_data_tar,treat_vec_name)
-      return_vec[i] <- es
+    input_data_res <- input_data[,!(colnames(input_data) %in% treat_vec_name)]
+    if(!is.data.frame(input_data_res)){
+        es         <- fun_sef(input_data,treat_vec_name)
+        names(es)  <-  colnames(input_data)[!(colnames(input_data) %in% treat_vec_name)]
+        return_vec <- es
+    }else{
+        val_names_vec <- colnames(input_data_res)
+        return_vec    <- vector(length = length(val_names_vec))
+        for(i in 1:length(val_names_vec)){
+            val_neme       <- val_names_vec[i]
+            input_data_tar <- input_data[,c(treat_vec_name,val_neme)]
+            es             <- fun_sef(input_data_tar,treat_vec_name)
+            return_vec[i]  <- es
+        }
+        names(return_vec) <- val_names_vec
     }
-    names(return_vec) <- val_names_vec
-  }
-  return(return_vec)
+    return(return_vec)
 }
 
-#fun_sef_df(input_data,treat_vec_name)
+##fun_sef_df(input_data,treat_vec_name)

--- a/R/rStddif.R
+++ b/R/rStddif.R
@@ -24,7 +24,7 @@ fun_sef_num <- function (vec_tr, vec_con) {
     e_tr  <- mean(vec_tr)
     e_con <- mean(vec_con)
     S     <- (var(vec_tr) + var(vec_con))/2
-    es    <- sqrt((e_tr - e_con)^2/S)
+    es    <- (e_tr - e_con) / sqrt(S)           # It should be allowed to be negative.
     return(es)
 }
 


### PR DESCRIPTION
This pull request consists of code realignment for readability and a minor modification to allow the standardize differences for continuous variables to be negative.

The standardized differences can be negative in the original stddiff SAS macro, as seen in the online documentation (http://support.sas.com/resources/papers/proceedings12/335-2012.pdf; Page 5; Table 3). It is implemented as follows in the original SAS version.

```
(a._mean_ - b._mean_) / sqrt((a._std_**2 + b._std_**2)/2)
```
